### PR TITLE
Subtitle Enhancements

### DIFF
--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -381,16 +381,13 @@ GuiPlayer.setCurrentTime = function(time) {
 				this.subtitleShowingIndex++;
 			}
 			if (this.currentTime >= this.PlayerDataSubtitle[this.subtitleShowingIndex].startTime && this.currentTime < this.PlayerDataSubtitle[this.subtitleShowingIndex].endTime && document.getElementById("guiPlayer_Subtitles").innerHTML != this.PlayerDataSubtitle.text) {
-				var subtitleText = this.PlayerDataSubtitle[this.subtitleShowingIndex].text; 
+				var subtitleText = this.PlayerDataSubtitle[this.subtitleShowingIndex].text;
 				subtitleText = subtitleText.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br />$2'); //support two-line subtitles
-				var start = subtitleText.substring(0, 6);
-				var end = subtitleText.substring(subtitleText.length -7, subtitleText.length -1);
-				if (start == "<br />") {
-					subtitleText = subtitleText.substring(7, subtitleText.length -1);
-				}
-				if (end == "<br />") {
-					subtitleText = subtitleText.substring(0, subtitleText.length -7);
-				}
+
+				// remove redundant breaks
+				subtitleText = subtitleText.replace(/^<br \/>/, '');
+				subtitleText = subtitleText.replace(/<br \/>$/, '');
+
 				document.getElementById("guiPlayer_Subtitles").innerHTML = subtitleText; 
 				document.getElementById("guiPlayer_Subtitles").style.visibility = "";
 			}

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -231,6 +231,11 @@ GuiPlayer.setSubtitles = function(selectedSubtitleIndex) {
 		    }catch(e){
 		        alert(e); //error in the above string(in this case,yes)!
 		    }
+
+			// subtitles may not be sorted ascending by startTime, but we require it
+			this.PlayerDataSubtitle.sort(function(a, b) {
+				return a.startTime - b.startTime;
+			});
 		}
 	}
 };

--- a/app/javascript/Support/polyfill.js
+++ b/app/javascript/Support/polyfill.js
@@ -1,0 +1,15 @@
+if (!Array.prototype.findIndex) {
+	Array.prototype.findIndex = function(predicate, thisArg) {
+		if (typeof predicate !== 'function') {
+			throw new TypeError('predicate must be a function');
+		}
+
+		var lastIndex = -1;
+		if (!Array.prototype.some.call(this, function(val, index, arr) {
+			return predicate.call(thisArg, val, lastIndex = index, arr);
+		})) {
+			return -1;
+		}
+		return lastIndex;
+	};
+}

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
 		<script language="javascript" type="text/javascript" src="app/javascript/Gui/GuiPage_Playlist.js"></script>
 		<script language="javascript" type="text/javascript" src="app/javascript/Gui/GuiPage_AddToPlaylist.js"></script>
 		<script language="javascript" type="text/javascript" src="app/javascript/Gui/GuiPage_Search.js"></script>
+		<script src="app/javascript/Support/polyfill.js"></script>
 		
 		<object id="pluginPlayer" border=0 classid="clsid:SAMSUNG-INFOLINK-PLAYER"></object>
         <object id="pluginObjectAudio" border=0 classid="clsid:SAMSUNG-INFOLINK-AUDIO"></object>


### PR DESCRIPTION
Got 3 enhancements for subtitles:
1. When the subtitle mode is Always (and other selection methods fail), we should prefer a users native language before a non-native one. We could potentially add another option to always show subtitles if and only if one exists for the users native language.
2. Since the player only processes subtitles in order, we should ensure that order is based on time (I chose start time). In a perfect world, all subtitles are given in order. My specific use case are subs embedded in a mkv where multiple titles are on screen at the same time. This player doesn't support that and it's kind of ambiguous what to do with only a single subtitle box. Emby produces srt with subs that are out of order (based on start/end time). We should do something better than the appearance of missing subs when subs for the credits happen to be ordered before subs of the actual video. It's arguable whether a fix should be server side, but it's always good having more support client-side as well.
3. An off-by one error when subtitles end with a newline resulting in truncated subs.

Tested on the emulator and a D-series tv.
