### PR TITLE
Transcode render error7

### DIFF
--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -366,10 +366,17 @@ GuiPlayer.handleAuthenticationFailed = function() {
 };
 
 GuiPlayer.handleRenderError = function(RenderErrorType) {
-	FileLog.write("Playback : Render Error " + RenderErrorType);
-    GuiNotifications.setNotification("Rendor Error Type : " + RenderErrorType);
-    GuiPlayer.stopPlayback();
-    GuiPlayer_Display.restorePreviousMenu();
+	if (RenderErrorType == 7 && this.PlayMethod == "DirectPlay") {
+    	FileLog.write("Playback : Render Error (7) while trying to DirectPlay.  Attempting playback with Transcoding...");
+    	GuiNotifications.setNotification("Render Error (7) while trying to DirectPlay.<br>Attempting playback with Transcoding...");
+	    GuiPlayer.stopPlayback();
+    	GuiPlayer_Versions.start(this.PlayerData,0,this.startParams[3],true);
+	}else {
+		FileLog.write("Playback : Render Error " + RenderErrorType);
+	    GuiNotifications.setNotification("Render Error Type : " + RenderErrorType);
+	    GuiPlayer.stopPlayback();
+	    GuiPlayer_Display.restorePreviousMenu();
+	}
 };
 
 GuiPlayer.handleStreamNotFound = function() {

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -367,12 +367,12 @@ GuiPlayer.handleAuthenticationFailed = function() {
 
 GuiPlayer.handleRenderError = function(RenderErrorType) {
 	if (RenderErrorType == 7 && this.PlayMethod == "DirectPlay") {
-    	FileLog.write("Playback : Render Error (7) while trying to DirectPlay.  Attempting playback with Transcoding...");
-    	GuiNotifications.setNotification("Render Error (7) while trying to DirectPlay.<br>Attempting playback with Transcoding...");
+	    FileLog.write("Playback : Render Error (7) while trying to DirectPlay.  Attempting playback with Transcoding...");
+	    GuiNotifications.setNotification("Render Error (7) while trying to DirectPlay.<br>Attempting playback with Transcoding...");
 	    GuiPlayer.stopPlayback();
-    	GuiPlayer_Versions.start(this.PlayerData,0,this.startParams[3],true);
-	}else {
-		FileLog.write("Playback : Render Error " + RenderErrorType);
+	    GuiPlayer_Versions.start(this.PlayerData,0,this.startParams[3],true);
+	} else {
+	    FileLog.write("Playback : Render Error " + RenderErrorType);
 	    GuiNotifications.setNotification("Render Error Type : " + RenderErrorType);
 	    GuiPlayer.stopPlayback();
 	    GuiPlayer_Display.restorePreviousMenu();

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer_Transcoding.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer_Transcoding.js
@@ -35,7 +35,7 @@ var GuiPlayer_Transcoding = {
 }
 
 //--------------------------------------------------------------------------------------
-GuiPlayer_Transcoding.start = function(showId, MediaSource,MediaSourceIndex, videoIndex, audioIndex, isFirstAudioIndex, subtitleIndex) {	
+GuiPlayer_Transcoding.start = function(showId, MediaSource,MediaSourceIndex, videoIndex, audioIndex, isFirstAudioIndex, subtitleIndex,forceVideoTranscode) {	
 	//Set Class Vars
 	this.MediaSource = MediaSource;
 	this.videoIndex = videoIndex;
@@ -63,6 +63,11 @@ GuiPlayer_Transcoding.start = function(showId, MediaSource,MediaSourceIndex, vid
 	   streamAudioCodec = (File.getTVProperty("Dolby") && File.getTVProperty("AACtoDolby") && fileAudioCodec == "aac") ? "ac3" : fileAudioCodec;
 	}
 	
+	if (forceVideoTranscode !== undefined && forceVideoTranscode == true) {
+		FileLog.write("Forcing Video Transcoding");
+		this.isVideo = false;
+	}
+
 	if (this.isVideo && this.isAudio && convertAACtoDolby == false) {
 		if (isFirstAudioIndex == true) {
 			transcodeStatus = "Direct Play";

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer_Versions.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer_Versions.js
@@ -20,7 +20,7 @@ var GuiPlayer_Versions = {
 		MediaSelections : [],
 }
 
-GuiPlayer_Versions.start = function(playerData,resumeTicks,playedFromPage) {
+GuiPlayer_Versions.start = function(playerData,resumeTicks,playedFromPage, forceVideoTranscode) {
 	//Reset Vars
 	this.MediaOptions.length = 0;
 	this.MediaPlayback.length = 0;
@@ -59,8 +59,8 @@ GuiPlayer_Versions.start = function(playerData,resumeTicks,playedFromPage) {
 	FileLog.write("Video : Determine Playback of Media Streams");
 	for (var index = 0; index < this.MediaOptions.length; index++) {
 		var result = GuiPlayer_Transcoding.start(this.PlayerData.Id, this.PlayerData.MediaSources[this.MediaOptions[index][0]],this.MediaOptions[index][0],
-			this.MediaOptions[index][1],this.MediaOptions[index][2],this.MediaOptions[index][3],this.MediaOptions[index][4]);
-			FileLog.write("Video : Playback Added")
+			this.MediaOptions[index][1],this.MediaOptions[index][2],this.MediaOptions[index][3],this.MediaOptions[index][4],forceVideoTranscode);
+			FileLog.write("Video : Playback Added");
 			this.MediaPlayback.push(result);	
 	}
 	


### PR DESCRIPTION
Hi cmcg,

SamES here.  I've got some avi files with GMC warp points.  They won't play and generate RenderError 7.  Looking in the server API, it does not look possible to detect this format before playback, so I've made a small change to fall-back to transcoding when render error 7 is generated.

Basically, it will display the user notification message and explain that Direct Play failed and then it will try and force transcoding.  To do this, you will see I've added an extra flag to force the transcoding to occur.  I considered not displaying a message but it is handy if the user expected it to direct play, at least they can raise it as a bug if it should be a supported format.

There may be a better way, but this looked OK to me.  I think some form of fall-back to transcode should be implemented for Render Error 7. 

For completeness and to prevent future confusion/bugs, you may want to add parameter forceVideoTranscode=false to all the other calls to GuiPlayer_Versions.start() and  GuiPlayer_Transcoding.start()
